### PR TITLE
More random changes

### DIFF
--- a/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/Standalone.groovy
+++ b/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/Standalone.groovy
@@ -28,13 +28,10 @@ class Standalone implements TranslationCheckBatchJob {
         parser = new OptionParser()
         baseDirs = parser.nonOptions("dir").ofType(File.class)
         template = parser.accepts("template").withRequiredArg().defaultsTo("en_US.lang")
-        //excludedFilenames = parser.accepts("exclude").withRequiredArg().defaultsTo(new String[0])
         excludedFilenames = parser.accepts("exclude").withRequiredArg().ofType(String.class).defaultsTo()
         singleMode = parser.accepts("single").withRequiredArg()
         output = parser.accepts("output").availableIf(singleMode).withRequiredArg()
-        //validators = parser.accepts("validators")withRequiredArg().ofType(String.class).defaultsTo(Validators.allValidators)
-        validators = parser.accepts("validators").withRequiredArg().ofType(String.class)
-                .defaultsTo(Validators.allValidatorsAsString)
+        validators = parser.accepts("validators").withRequiredArg().ofType(String.class).defaultsTo(Validators.allValidatorsAsString)
         marker = parser.accepts("marker").withRequiredArg().ofType(String.class).defaultsTo("## NEEDS TRANSLATION ##")
         dryRun = parser.accepts("dry-run", "runs without modyfing any files")
         help = parser.accepts("help").forHelp()
@@ -54,7 +51,7 @@ class Standalone implements TranslationCheckBatchJob {
 
         boolean isSingleMode = options.has(singleMode)
         boolean isDryRun = options.has(dryRun)
-        Set<String> validatorSet = new HashSet<>(options.valuesOf(validators))
+        Set<String> validatorSet = new HashSet<>(options.valueOf(validators).tokenize(','))
         for (File baseDir : options.valuesOf(baseDirs)) {
             println "Starting " + baseDir.getAbsolutePath()
             if (isSingleMode) {

--- a/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/tasks/TranslationCheckTask.groovy
+++ b/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/tasks/TranslationCheckTask.groovy
@@ -40,6 +40,9 @@ class TranslationCheckTask extends DefaultTask implements TranslationCheckBatchJ
     @Input
     boolean dryRun = false
 
+    @Input
+    String lineEnding = "\n"
+
     def log(String log) {
         logger.info(log)
     }
@@ -67,6 +70,7 @@ class TranslationCheckTask extends DefaultTask implements TranslationCheckBatchJ
                     templateFile.loadValidators(validators)
                     templateFile.needsTranslationMarker = needsTranslationMark
                     templateFile.dryRun = dryRun
+                    templateFile.lineEnding = lineEnding
         } as TranslationTemplateConfigurator)
     }
 }

--- a/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/tasks/TranslationCheckTask.groovy
+++ b/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/tasks/TranslationCheckTask.groovy
@@ -37,6 +37,9 @@ class TranslationCheckTask extends DefaultTask implements TranslationCheckBatchJ
     @Input
     String[] enabledValidators = Validators.allValidators
 
+    @Input
+    boolean dryRun = false
+
     def log(String log) {
         logger.info(log)
     }
@@ -63,6 +66,7 @@ class TranslationCheckTask extends DefaultTask implements TranslationCheckBatchJ
         { TranslationFileTemplate templateFile ->
                     templateFile.loadValidators(validators)
                     templateFile.needsTranslationMarker = needsTranslationMark
+                    templateFile.dryRun = dryRun
         } as TranslationTemplateConfigurator)
     }
 }

--- a/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/translation/TranslationFileTemplate.groovy
+++ b/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/translation/TranslationFileTemplate.groovy
@@ -29,6 +29,8 @@ class TranslationFileTemplate {
 
     public String needsTranslationMarker =  "## NEEDS TRANSLATION ##"
 
+    public boolean dryRun = false
+
     private List<LineTemplate> templates = []
 
     def loadValidators(Set<String> ids) {
@@ -104,13 +106,13 @@ class TranslationFileTemplate {
     def processTranslation(File inFile, File outFile) {
         def translations = inFile.withReader('UTF-8') { parseProperties(it) }
         validateTranslation(translations, outFile.getAbsolutePath())
-        outFile.withWriter('UTF-8') { fillFromTemplate(it, translations) }
+        if (!dryRun) outFile.withWriter('UTF-8') { fillFromTemplate(it, translations) }
     }
 
     def processTranslation(Reader reader, BufferedWriter writer) {
         def translations = reader.withCloseable { parseProperties((Reader) it) }
         validateTranslation(translations, "<stream>")
-        writer.withCloseable { fillFromTemplate((BufferedWriter) it, translations) }
+        if (!dryRun) writer.withCloseable { fillFromTemplate(it as BufferedWriter, translations) }
     }
 }
 

--- a/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/translation/TranslationFileTemplate.groovy
+++ b/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/translation/TranslationFileTemplate.groovy
@@ -31,6 +31,8 @@ class TranslationFileTemplate {
 
     public boolean dryRun = false
 
+    public String lineEnding = "\n"
+
     private List<LineTemplate> templates = []
 
     def loadValidators(Set<String> ids) {
@@ -100,7 +102,10 @@ class TranslationFileTemplate {
     }
 
     def fillFromTemplate(BufferedWriter output, Map<String, String> translations) {
-        templates.each { output.writeLine(it.fill(translations)) }
+        templates.each {
+            output.write(it.fill(translations))
+            output.write(lineEnding)
+        }
     }
 
     def processTranslation(File inFile, File outFile) {

--- a/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/validation/Validators.groovy
+++ b/src/main/groovy/net/thesilkminer/gradle/plugin/translationchecker/validation/Validators.groovy
@@ -29,19 +29,12 @@ class Validators {
     }
 
     static String getAllValidatorsAsString() {
-        return Arrays.toString(allValidators)
-    }
-
-    static String[] unWrap(final String validators) {
-        String unwrapped = validators
-        unwrapped = unwrapped.replace('[', '')
-        unwrapped = unwrapped.replace(']', '')
-
-        String[] unwrappedArray = unwrapped.split(Pattern.quote(", "))
-        unwrappedArray
+        return  VALIDATORS.keySet().join(",")
     }
 
     static Validator create(String id) {
-        return VALIDATORS[id].create()
+        ValidatorFactory factory = VALIDATORS[id]
+        if (factory == null) throw new IllegalArgumentException("Unknown validator: " + id)
+        return factory.create()
     }
 }


### PR DESCRIPTION
- dry-run option - for validation only
- system-independent line endings
- fixing standalone mode (broken due to invalid 'validators' format)
